### PR TITLE
Fixed a nil value error on itemframe's qualityTexture.

### DIFF
--- a/Modules/GearInfos.lua
+++ b/Modules/GearInfos.lua
@@ -70,19 +70,23 @@ end
 ---@param value boolean @True if the frames should be shown, false otherwise
 function GearInfos:ToggleColorFrames(value)
     for _, gearFrame in ipairs(GEAR_SLOT_FRAMES) do
-        if value then
-            gearFrame.qualityTexture:Show()
-        else
-            gearFrame.qualityTexture:Hide()
-        end
+		if gearFrame.qualityTexture ~= nil then
+			if value then
+				gearFrame.qualityTexture:Show()
+			else
+				gearFrame.qualityTexture:Hide()
+			end
+		end
     end
     for _, gearFrame in ipairs(_GetInspectGearSlots()) do
-        if value then
-            gearFrame.qualityTexture:Show()
-        else
-            gearFrame.qualityTexture:Hide()
-        end
-    end
+		if gearFrame.qualityTexture ~= nil then
+			if value then
+				gearFrame.qualityTexture:Show()
+			else
+				gearFrame.qualityTexture:Hide()
+			end
+		end
+	end
 end
 
 _GetInspectGearSlots = function()


### PR DESCRIPTION
Hi,

I been having this lua error everytime I log in or do /reload.
I decided to fix it for my self, but the last update brought the problem back so I decided to make this pr.

It is possible that my other addons are somehow the cause of the issue, but regardless this code change is just a nil check in a for loop and shouldn't do any harm.

![](https://i.gyazo.com/aec02afb452f90a498465f209415242f.png)

![](https://i.gyazo.com/8ce9ce1dee000c72984d810cc16ba5a9.png)
