### PR TITLE
fix: ranged hit talent bonus for classic SOM

### DIFF
--- a/Modules/Data/Melee.lua
+++ b/Modules/Data/Melee.lua
@@ -55,7 +55,7 @@ function _Melee:GetHitTalentBonus()
         mod = points * 1 -- 0-3% Precision
     end
 
-    if classId == Data.HUNTER then
+    if ECS.IsTBC and classId == Data.HUNTER then
         local _, _, _, _, points, _, _, _ = GetTalentInfo(3, 12)
         mod = points * 1 -- 0-3% Surefooted
     end

--- a/Modules/Data/Ranged.lua
+++ b/Modules/Data/Ranged.lua
@@ -74,7 +74,7 @@ end
 function _Ranged:GetHitTalentBonus()
     local bonus = 0
 
-    if classId == Data.HUNTER then
+    if ECS.IsTBC and classId == Data.HUNTER then
         local _, _, _, _, points, _, _, _ = GetTalentInfo(3, 12)
         bonus = points * 1 -- 0-3% Surefooted
     end


### PR DESCRIPTION
In classic the hit talent bonus is part of the return value of `GetHitModifier`. Since the function `GetHitTalentBonus` is only used for the TBC context I would suggest this easy fix, tough it is a bit confusing in a classic context as `GetHitTalentBonus` will return 0, eventough the 'correct' value would be `3`.

Also note that in classic the talent column would be `11` and not `12`, if you would rather go that route.

~~This change should also happen in the `Melee.lua` file, which I will add in another commit.~~