### PR TITLE
Fix value of mp5 (items), changed mp5 (spirit)

### DIFF
--- a/Modules/Config/ManaSection.lua
+++ b/Modules/Config/ManaSection.lua
@@ -79,6 +79,19 @@ function _Config:LoadManaSection()
                     Stats:RebuildStatInfos()
                 end,
             },
+            InnervateMana = {
+                type = "toggle",
+                order = 5,
+                name = function() return i18n("Innervate mana") end,
+                desc = function() return i18n("Shows/Hides the total mana regen from innervate.") end,
+                width = 1.5,
+                disabled = function() return (not ExtendedCharacterStats.profile.regen.display); end,
+                get = function () return ExtendedCharacterStats.profile.regen.InnervateMana.display; end,
+                set = function (_, value)
+                    ExtendedCharacterStats.profile.regen.InnervateMana.display = value
+                    Stats:RebuildStatInfos()
+                end,
+            },
         },
     }
 end

--- a/Modules/Config/ManaSection.lua
+++ b/Modules/Config/ManaSection.lua
@@ -82,7 +82,7 @@ function _Config:LoadManaSection()
             mp5NotCasting = {
                 type = "toggle",
                 order = 5,
-                name = "MP5 (not casting)",
+                name = function() return i18n("MP5 (not casting)") end,
                 desc = "Shows/Hides the MP5 value when outside of the 5 second rule.",
                 width = 1.5,
                 disabled = function() return (not ExtendedCharacterStats.profile.regen.display); end,

--- a/Modules/Config/ManaSection.lua
+++ b/Modules/Config/ManaSection.lua
@@ -92,19 +92,6 @@ function _Config:LoadManaSection()
                     Stats:RebuildStatInfos()
                 end,
             },
-            InnervateMana = {
-                type = "toggle",
-                order = 6,
-                name = function() return i18n("Innervate mana") end,
-                desc = function() return i18n("Shows/Hides the total mana regen from innervate.") end,
-                width = 1.5,
-                disabled = function() return (not ExtendedCharacterStats.profile.regen.display); end,
-                get = function () return ExtendedCharacterStats.profile.regen.InnervateMana.display; end,
-                set = function (_, value)
-                    ExtendedCharacterStats.profile.regen.InnervateMana.display = value
-                    Stats:RebuildStatInfos()
-                end,
-            },
         },
     }
 end

--- a/Modules/Config/ManaSection.lua
+++ b/Modules/Config/ManaSection.lua
@@ -79,9 +79,22 @@ function _Config:LoadManaSection()
                     Stats:RebuildStatInfos()
                 end,
             },
-            InnervateMana = {
+            mp5NotCasting = {
                 type = "toggle",
                 order = 5,
+                name = "MP5 (not casting)",
+                desc = "Shows/Hides the MP5 value when outside of the 5 second rule.",
+                width = 1.5,
+                disabled = function() return (not ExtendedCharacterStats.profile.regen.display); end,
+                get = function () return ExtendedCharacterStats.profile.regen.mp5NotCasting.display; end,
+                set = function (_, value)
+                    ExtendedCharacterStats.profile.regen.mp5NotCasting.display = value
+                    Stats:RebuildStatInfos()
+                end,
+            },
+            InnervateMana = {
+                type = "toggle",
+                order = 6,
                 name = function() return i18n("Innervate mana") end,
                 desc = function() return i18n("Shows/Hides the total mana regen from innervate.") end,
                 width = 1.5,

--- a/Modules/Config/ManaSection.lua
+++ b/Modules/Config/ManaSection.lua
@@ -83,7 +83,7 @@ function _Config:LoadManaSection()
                 type = "toggle",
                 order = 5,
                 name = function() return i18n("MP5 (not casting)") end,
-                desc = "Shows/Hides the MP5 value when outside of the 5 second rule.",
+                desc = function() return i18n("Shows/Hides the MP5 value when outside of the 5 second rule.") end,
                 width = 1.5,
                 disabled = function() return (not ExtendedCharacterStats.profile.regen.display); end,
                 get = function () return ExtendedCharacterStats.profile.regen.mp5NotCasting.display; end,

--- a/Modules/Data/Constants.lua
+++ b/Modules/Data/Constants.lua
@@ -35,7 +35,16 @@ Data.enchantIds = {
     BRACER_MANA_REGENERATION = "2565", -- 4 MP5 on bracer
     PROPHETIC_AURA = "2590", -- 4 MP5 for priest ZG Enchant
     RESILIENCE_OF_THE_SCOURGE = "2715", -- 4 MP5 for priest ZG Enchant
+    INSCRIPTION_OF_FAITH = "2980", -- 4 MP5 from aldor enchant
+    GLYPH_OF_RENEWAL = "3001", -- 7 MP5 from Honor Hold/Thrallmar enchant
     BRILLIANT_MANA_OIL = "2629", -- 12 MP5
     LESSER_MANA_OIL = "2625", -- 8 MP5
     MINOR_MANA_OIL = "2624", -- 4 MP5
+}
+
+Data.gemIds = {
+    FOUR_MP5_GEMS = {"32202"},
+    THREE_MP5_GEMS = {"24037"},
+    TWO_MP5_GEMS = {"30589", "32225", "24065", "30594", "31865", "32214", "30606", "23121", "24057", "32216", "30603", "30560", "30550"},
+    ONE_MP5_GEMS = {"23106", "31864", "28465", "23109"}
 }

--- a/Modules/Data/Data.lua
+++ b/Modules/Data/Data.lua
@@ -143,6 +143,7 @@ dataFunctionRefs = {
         return mp5Buffs
     end,
     ["MP5Casting"] = function() return Data:GetMP5WhileCasting() end,
+    ["InnervateMana"] = function() return Data:GetInnervateManaRen() end,
     -- Spell Power by school
     ["PhysicalDmg"] = function() return Data:GetSpellDamage(Data.PHYSICAL_SCHOOL) end,
     ["HolyDmg"] = function() return Data:GetSpellDamage(Data.HOLY_SCHOOL) end,

--- a/Modules/Data/Data.lua
+++ b/Modules/Data/Data.lua
@@ -161,7 +161,6 @@ dataFunctionRefs = {
     end,
     ["MP5Casting"] = function() return Data:GetMP5WhileCasting() end,
     ["MP5NotCasting"] = function() return Data:GetMP5OutsideCasting() end,
-    ["InnervateMana"] = function() return Data:GetInnervateManaRen() end,
     -- Spell Power by school
     ["PhysicalDmg"] = function() return Data:GetSpellDamage(Data.PHYSICAL_SCHOOL) end,
     ["HolyDmg"] = function() return Data:GetSpellDamage(Data.HOLY_SCHOOL) end,

--- a/Modules/Data/Data.lua
+++ b/Modules/Data/Data.lua
@@ -160,6 +160,7 @@ dataFunctionRefs = {
         return mp5Buffs
     end,
     ["MP5Casting"] = function() return Data:GetMP5WhileCasting() end,
+    ["MP5NotCasting"] = function() return Data:GetMP5OutsideCasting() end,
     ["InnervateMana"] = function() return Data:GetInnervateManaRen() end,
     -- Spell Power by school
     ["PhysicalDmg"] = function() return Data:GetSpellDamage(Data.PHYSICAL_SCHOOL) end,

--- a/Modules/Data/DataUtils.lua
+++ b/Modules/Data/DataUtils.lua
@@ -49,3 +49,15 @@ function DataUtils:GetEnchantFromItemLink(itemLink)
 
     return nil
 end
+
+function DataUtils:GetSocketedGemsFromItemLink(itemLink)
+    if itemLink then
+        local _, itemStringLink = GetItemInfo(itemLink)
+        if itemStringLink then
+            local _, _, gem1, gem2, gem3 = string.find(itemStringLink, "item:%d*:%d*:(%d*):(%d*):(%d*)")
+            return gem1, gem2, gem3
+        end
+    end
+
+    return nil
+end

--- a/Modules/Data/MP5.lua
+++ b/Modules/Data/MP5.lua
@@ -132,6 +132,15 @@ function Data:GetMP5WhileCasting()
     return DataUtils:Round(casting, 2)
 end
 
+function Data:GetMP5OutsideCasting()
+    local base, _ = GetManaRegen() -- Returns mana reg per 1 second
+    if base < 1 then
+        base = lastManaReg
+    end
+    lastManaReg = base
+    return base * 5
+end
+
 ---@return number
 function _MP5:GetTalentModifier()
     local mod = 0

--- a/Modules/Data/MP5.lua
+++ b/Modules/Data/MP5.lua
@@ -48,7 +48,6 @@ function _MP5:GetMP5ValueOnItems()
             if enchant and enchant == Data.enchantIds.INSCRIPTION_OF_FAITH then
                 mp5 = mp5 + 4
             end
-            
             -- Check for socketed gems (TODO: check for socket bonus)
             local gem1, gem2, gem3 = DataUtils:GetSocketedGemsFromItemLink(itemLink)
             if gem1 then
@@ -62,7 +61,6 @@ function _MP5:GetMP5ValueOnItems()
             end
         end
     end
-
 
     -- Check weapon enchants (e.g. Mana Oil)
     local hasMainEnchant, _, _, mainHandEnchantID = GetWeaponEnchantInfo()

--- a/Modules/Data/MP5.lua
+++ b/Modules/Data/MP5.lua
@@ -40,8 +40,29 @@ function _MP5:GetMP5ValueOnItems()
             if enchant and enchant == Data.enchantIds.RESILIENCE_OF_THE_SCOURGE then
                 mp5 = mp5 + 5
             end
+            -- Honor Hold/Thrallmar enchant
+            if enchant and enchant == Data.enchantIds.GLYPH_OF_RENEWAL then
+                mp5 = mp5 + 7
+            end
+            -- aldor enchant
+            if enchant and enchant == Data.enchantIds.INSCRIPTION_OF_FAITH then
+                mp5 = mp5 + 4
+            end
+            
+            -- Check for socketed gems (TODO: check for socket bonus)
+            local gem1, gem2, gem3 = DataUtils:GetSocketedGemsFromItemLink(itemLink)
+            if gem1 then
+                mp5 = mp5 + _MP5:GetGemBonusMP5(gem1)
+            end
+            if gem2 then
+                mp5 = mp5 + _MP5:GetGemBonusMP5(gem2)
+            end
+            if gem3 then
+                mp5 = mp5 + _MP5:GetGemBonusMP5(gem3)
+            end
         end
     end
+
 
     -- Check weapon enchants (e.g. Mana Oil)
     local hasMainEnchant, _, _, mainHandEnchantID = GetWeaponEnchantInfo()
@@ -65,12 +86,19 @@ local lastManaReg = 0
 
 ---@return number
 function Data:GetMP5FromSpirit()
+    local _, intValue = UnitStat("player", 4)
+    local _, spiritValue = UnitStat("player", 5)
+    return DataUtils:Round((0.001 + (spiritValue * 0.009327 * (intValue^0.5))) * 5, 1)
+end
+
+---@return number
+function Data:GetInnervateManaRen()
     local base, _ = GetManaRegen() -- Returns mana reg per 1 second
     if base < 1 then
         base = lastManaReg
     end
     lastManaReg = base
-    return DataUtils:Round(base * 5, 1)
+    return DataUtils:Round(base * 5 * 16, 0) -- total mana regened by innervate
 end
 
 -- Get mana regen while casting
@@ -294,4 +322,29 @@ function _MP5:GetBlessingOfWisdomModifier()
         mod = points * 0.1 -- 0-20% from Improved Blessing of Wisdom
     end
     return mod
+end
+
+---@return number
+function _MP5:GetGemBonusMP5(gemId)
+    for _, value in ipairs(Data.gemIds.FOUR_MP5_GEMS) do
+        if value == gemId then
+            return 4
+        end
+    end
+    for _, value in ipairs(Data.gemIds.THREE_MP5_GEMS) do
+        if value == gemId then
+            return 3
+        end
+    end
+    for _, value in ipairs(Data.gemIds.TWO_MP5_GEMS) do
+        if value == gemId then
+            return 2
+        end
+    end
+    for _, value in ipairs(Data.gemIds.ONE_MP5_GEMS) do
+        if value == gemId then
+            return 1
+        end
+    end
+    return 0
 end

--- a/Modules/Data/MP5.lua
+++ b/Modules/Data/MP5.lua
@@ -89,16 +89,6 @@ function Data:GetMP5FromSpirit()
     return DataUtils:Round((0.001 + (spiritValue * 0.009327 * (intValue^0.5))) * 5, 1)
 end
 
----@return number
-function Data:GetInnervateManaRen()
-    local base, _ = GetManaRegen() -- Returns mana reg per 1 second
-    if base < 1 then
-        base = lastManaReg
-    end
-    lastManaReg = base
-    return DataUtils:Round(base * 5 * 16, 0) -- total mana regened by innervate
-end
-
 -- Get mana regen while casting
 ---@return number
 function Data:GetMP5WhileCasting()

--- a/Modules/Profile.lua
+++ b/Modules/Profile.lua
@@ -266,13 +266,6 @@ local function GetDefaultStatsProfile()
                 textColor = colors.MP5_SECONDARY,
                 statColor = colors.MP5_PRIMARY
             },
-            InnervateMana = {
-                display = true,
-                refName = "InnervateMana",
-                text = "Innervate mana",
-                textColor = colors.MP5_SECONDARY,
-                statColor = colors.MP5_PRIMARY
-            },
         },
 
         ---@type Category

--- a/Modules/Profile.lua
+++ b/Modules/Profile.lua
@@ -259,6 +259,13 @@ local function GetDefaultStatsProfile()
                 textColor = colors.MP5_SECONDARY,
                 statColor = colors.MP5_PRIMARY
             },
+            mp5NotCasting = {
+                display = true,
+                refName = "MP5NotCasting",
+                text = "MP5 (Not casting)",
+                textColor = colors.MP5_SECONDARY,
+                statColor = colors.MP5_PRIMARY
+            },
             InnervateMana = {
                 display = true,
                 refName = "InnervateMana",

--- a/Modules/Profile.lua
+++ b/Modules/Profile.lua
@@ -242,6 +242,13 @@ local function GetDefaultStatsProfile()
                 textColor = colors.MP5_SECONDARY,
                 statColor = colors.MP5_PRIMARY
             },
+            InnervateMana = {
+                display = true,
+                refName = "InnervateMana",
+                text = "Innervate mana",
+                textColor = colors.MP5_SECONDARY,
+                statColor = colors.MP5_PRIMARY
+            },
         },
 
         ---@type Category

--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -209,7 +209,7 @@ _CreateStatInfos = function()
             category.blockChance, category.blockValue, category.parry, category.dodge, category.resilience)
 
     category = profile.regen
-    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting)
+    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.InnervateMana)
 
     category = profile.spell
     _CreateStatInfo(category, category.crit, category.hasteRating, category.hasteBonus, category.penetration)

--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -210,7 +210,7 @@ _CreateStatInfos = function()
             category.defense, category.blockChance, category.blockValue, category.parry, category.dodge, category.resilience)
 
     category = profile.regen
-    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.InnervateMana)
+    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting, category.InnervateMana)
 
     category = profile.spell
     _CreateStatInfo(category, category.crit, category.hasteRating, category.hasteBonus, category.penetration)

--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -210,8 +210,7 @@ _CreateStatInfos = function()
             category.defense, category.blockChance, category.blockValue, category.parry, category.dodge, category.resilience)
 
     category = profile.regen
-    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting,
-            category.InnervateMana)
+    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting)
 
     category = profile.spell
     _CreateStatInfo(category, category.crit, category.hasteRating, category.hasteBonus, category.penetration)

--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -210,7 +210,7 @@ _CreateStatInfos = function()
             category.defense, category.blockChance, category.blockValue, category.parry, category.dodge, category.resilience)
 
     category = profile.regen
-    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting, 
+    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting,
             category.InnervateMana)
 
     category = profile.spell

--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -210,7 +210,8 @@ _CreateStatInfos = function()
             category.defense, category.blockChance, category.blockValue, category.parry, category.dodge, category.resilience)
 
     category = profile.regen
-    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting, category.InnervateMana)
+    _CreateStatInfo(category, category.mp5Items, category.mp5Spirit, category.mp5Buffs, category.mp5Casting, category.mp5NotCasting, 
+            category.InnervateMana)
 
     category = profile.spell
     _CreateStatInfo(category, category.crit, category.hasteRating, category.hasteBonus, category.penetration)

--- a/Modules/i18n/translations/ConfigTranslations/ManaConfigTranslations.lua
+++ b/Modules/i18n/translations/ConfigTranslations/ManaConfigTranslations.lua
@@ -72,6 +72,20 @@ local manaConfigTranslations = {
         ["zhCN"] = "显示/隐藏 附魔回蓝",
         ["ruRU"] = "Показать/скрыть значение MP5 (восполнение маны каждые 5 сек вне боя) во время произношения заклинаний",
     },
+    ["Innervate mana"] = {
+        ["enUS"] = true,
+        ["deDE"] = "Anregen Manaregeneration",
+        ["frFR"] = "Mana d'Innervation",
+        ["zhCN"] = true,
+        ["ruRU"] = true,
+    },
+    ["Shows/Hides the total mana regen from innervate."] = {
+        ["enUS"] = true,
+        ["deDE"] = "Toont/verbergt de totale mana die door Innervate is gegenereerd.",
+        ["frFR"] = "Affiche/cache le total de mana regénéré par Innervation.",
+        ["zhCN"] = "显示/隐藏由 Innervate 再生的总法力值。",
+        ["ruRU"] = "Показывает/скрывает общее количество маны, регенерируемой Innervate.",
+    },
 }
 
 for k, v in pairs(manaConfigTranslations) do

--- a/Modules/i18n/translations/ConfigTranslations/ManaConfigTranslations.lua
+++ b/Modules/i18n/translations/ConfigTranslations/ManaConfigTranslations.lua
@@ -72,20 +72,6 @@ local manaConfigTranslations = {
         ["zhCN"] = "显示/隐藏 附魔回蓝",
         ["ruRU"] = "Показать/скрыть значение MP5 (восполнение маны каждые 5 сек вне боя) во время произношения заклинаний",
     },
-    ["Innervate mana"] = {
-        ["enUS"] = true,
-        ["deDE"] = "Anregen Manaregeneration",
-        ["frFR"] = "Mana d'Innervation",
-        ["zhCN"] = "支配法力",
-        ["ruRU"] = "Иннервировать ману",
-    },
-    ["Shows/Hides the total mana regen from innervate."] = {
-        ["enUS"] = true,
-        ["deDE"] = "Toont/verbergt de totale mana die door Innervate is gegenereerd.",
-        ["frFR"] = "Affiche/cache le total de mana regénéré par Innervation.",
-        ["zhCN"] = "显示/隐藏由 Innervate 再生的总法力值。",
-        ["ruRU"] = "Показывает/скрывает общее количество маны, регенерируемой Innervate.",
-    },
 }
 
 for k, v in pairs(manaConfigTranslations) do

--- a/Modules/i18n/translations/ConfigTranslations/ManaConfigTranslations.lua
+++ b/Modules/i18n/translations/ConfigTranslations/ManaConfigTranslations.lua
@@ -76,8 +76,8 @@ local manaConfigTranslations = {
         ["enUS"] = true,
         ["deDE"] = "Anregen Manaregeneration",
         ["frFR"] = "Mana d'Innervation",
-        ["zhCN"] = true,
-        ["ruRU"] = true,
+        ["zhCN"] = "支配法力",
+        ["ruRU"] = "Иннервировать ману",
     },
     ["Shows/Hides the total mana regen from innervate."] = {
         ["enUS"] = true,

--- a/Modules/i18n/translations/StatTranslations.lua
+++ b/Modules/i18n/translations/StatTranslations.lua
@@ -242,7 +242,7 @@ local statTranslations = {
     },
     ["MP5 (Not casting)"] = {
         ["enUS"] = true,
-        ["deDE"] = "MP5 (nicht übertragen)",
+        ["deDE"] = "MP5 (Nicht zaubernd)",
         ["frFR"] = "MP5 (pas de diffusion)",
         ["zhCN"] = "MP5（非铸造）",
         ["ruRU"] = "MP5 (без кастинга)",

--- a/Modules/i18n/translations/StatTranslations.lua
+++ b/Modules/i18n/translations/StatTranslations.lua
@@ -242,10 +242,10 @@ local statTranslations = {
     },
     ["MP5 (Not casting)"] = {
         ["enUS"] = true,
-        ["deDE"] = true,
-        ["frFR"] = true,
-        ["zhCN"] = true,
-        ["ruRU"] = true,
+        ["deDE"] = "MP5 (nicht übertragen)",
+        ["frFR"] = "MP5 (pas de diffusion)",
+        ["zhCN"] = "MP5（非铸造）",
+        ["ruRU"] = "MP5 (без кастинга)",
     },
     ["Spell"] = {
         ["enUS"] = true,

--- a/Modules/i18n/translations/StatTranslations.lua
+++ b/Modules/i18n/translations/StatTranslations.lua
@@ -240,6 +240,13 @@ local statTranslations = {
         ["zhCN"] = "附魔回蓝",
         ["ruRU"] = "MP5 (каст)",
     },
+    ["MP5 (Not casting)"] = {
+        ["enUS"] = true,
+        ["deDE"] = true,
+        ["frFR"] = true,
+        ["zhCN"] = true,
+        ["ruRU"] = true,
+    },
     ["Spell"] = {
         ["enUS"] = true,
         ["deDE"] = "Zauber",


### PR DESCRIPTION
Added a few tbc enchant and every mp5 gems to the "mp5 (items)" calculation. From now on, the only value missing is from gem socket bonus (I dont know a way to figure that one out).

Also renamed the current "mp5 (spirit)" to "mp5 (not casting)" and added the true "mp5 (spirit)" stat (matching the value found when hovering the spirit stat in the default interface).