### PR TITLE
Update mage Precision talent index

### DIFF
--- a/Modules/Data/SpellHit.lua
+++ b/Modules/Data/SpellHit.lua
@@ -66,7 +66,7 @@ function _SpellHit:GetTalentSpellHitBonus()
 
     if classId == Data.MAGE then
         if ECS.IsWotlk then
-            local _, _, _, _, points, _, _, _ = GetTalentInfo(3, 17)
+            local _, _, _, _, points, _, _, _ = GetTalentInfo(3, 6)
             bonus = points * 1 -- 0-3% from Elemental Precision
         else
             local _, _, _, _, points, _, _, _ = GetTalentInfo(3, 3)


### PR DESCRIPTION
Hello! I dont think the mage talent Precision from the Frost tree is being factored in correctly, it looks like the talentIndex is incorrect for wotlk talent trees. Not very experienced with addon dev so apologies if this is incorrect.

![image](https://user-images.githubusercontent.com/1553074/226210933-e4b350af-021a-42c2-ba0a-2e535aba93de.png)
