### PR TITLE
Add Classic Era version of Suppression (5-point talent)

### DIFF
--- a/Modules/Data/SpellHit.lua
+++ b/Modules/Data/SpellHit.lua
@@ -94,8 +94,13 @@ function _SpellHit:GetTalentSpellHitBonus()
     end
 
     if classId == Data.WARLOCK then
-        local _, _, _, _, points, _, _, _ = GetTalentInfo(1, 5)
-        bonus = points -- 0-3% from Suppression
+        if ECS.IsWotlk then
+            local _, _, _, _, points, _, _, _ = GetTalentInfo(1, 5)
+            bonus = points -- 0-3% from Suppression
+        else
+            local _, _, _, _, points, _, _, _ = GetTalentInfo(1, 5)
+            bonus = points * 2 -- 0-10% from Suppression
+        end
     end
 
     return bonus


### PR DESCRIPTION
Suppression in Wrath is a 3-point talent that adds bonus spell hit by 1/2/3%. In Classic Era, it is a 5-point talent that adds bonus spell hit by 2/4/6/8/10% for affliction spells.

This PR adds a condition to check which version of the should be used in calculating bonus spell hit. The effects of the talent on bonus spell hit is brought in line with how shadow priest's Shadow Focus is handled:

https://github.com/BreakBB/ExtendedCharacterStats/blob/82027f987da9b025e4432525ec192ca02b2ccf1b/Modules/Data/SpellHit.lua#L53-L59

Fixes #321 