### PR TITLE
[feature] Add setting to change item quality colors' intensity

### DIFF
--- a/Modules/Config/Config.lua
+++ b/Modules/Config/Config.lua
@@ -120,9 +120,24 @@ _GeneralTab = function()
                     ExtendedCharacterStats.general.showQualityColors = value
                 end,
             },
-            headerFontSize = {
+            qualityColorsIntensity = {
                 type = "range",
                 order = 4,
+                name = function() return i18n("Quality Colors' Intensity") end,
+                desc = function() return i18n("Changes the intensity of the colored frames' glow.") end,
+                width = "double",
+                min = 0.10,
+                max = 1.00,
+                step = 0.01,
+                get = function() return ExtendedCharacterStats.general.qualityColorsIntensity; end,
+                set = function (_, value)
+                    ExtendedCharacterStats.general.qualityColorsIntensity = value
+                    GearInfos.UpdateGearColorFrames()
+                end,
+            },
+            headerFontSize = {
+                type = "range",
+                order = 5,
                 name = function() return i18n("Header Font Size") end,
                 desc = function() return i18n("Changes the font size of the headers (e.g. Melee)") end,
                 width = "double",
@@ -137,7 +152,7 @@ _GeneralTab = function()
             },
             statFontSize = {
                 type = "range",
-                order = 5,
+                order = 6,
                 name = function() return i18n("Stat Font Size") end,
                 desc = function() return i18n("Changes the font size of the stat lines (e.g. Crit)") end,
                 width = "double",
@@ -152,7 +167,7 @@ _GeneralTab = function()
             },
             windowWidth = {
                 type = "range",
-                order = 6,
+                order = 7,
                 name = function() return i18n("Window Width") end,
                 desc = function() return i18n("Changes the width of the stats window") end,
                 width = "double",
@@ -167,7 +182,7 @@ _GeneralTab = function()
             },
             language = {
                 type = "select",
-                order = 7,
+                order = 8,
                 values = {
                     ["auto"] = "Auto",
                     ["enUS"] = "English",
@@ -199,13 +214,13 @@ _GeneralTab = function()
             },
             resetSpacer = {
                 type = "description",
-                order = 8,
+                order = 9,
                 name = " ",
                 width = "full"
             },
             reset = {
                 type = "execute",
-                order = 8.1,
+                order = 9.1,
                 name = function() return i18n("Reset ECS") end,
                 desc = function() return i18n("Restores all default values of ECS."); end,
                 func = function(_, _)

--- a/Modules/GearInfos.lua
+++ b/Modules/GearInfos.lua
@@ -57,7 +57,7 @@ _UpdateColorFrame = function (gearFrame, unit)
         if itemInfo ~= nil then
             local itemQuality = C_Item.GetItemQualityByID(itemInfo)
             local r, g, b, _ = GetItemQualityColor(itemQuality)
-            gearFrame.qualityTexture:SetVertexColor(r, g, b, 0.75)
+            gearFrame.qualityTexture:SetVertexColor(r, g, b, ExtendedCharacterStats.general.qualityColorsIntensity)
         end
     else
         C_Timer.After(0.2, function ()

--- a/Modules/Migration.lua
+++ b/Modules/Migration.lua
@@ -14,4 +14,9 @@ function Migration:ToLatestProfileVersion(profileVersion)
         ECS:Print(i18n("Profile has been reset due to a major update.")) -- v4.0.0 because of major spell restructuring
         return
     end
+    
+    local defaultProfile = Profile:GetDefaultProfile()
+    if profileVersion < 21 then
+        ExtendedCharacterStats.general.qualityColorsIntensity = defaultProfile.general.qualityColorsIntensity
+    end
 end

--- a/Modules/Migration.lua
+++ b/Modules/Migration.lua
@@ -14,6 +14,7 @@ function Migration:ToLatestProfileVersion(profileVersion)
         ECS:Print(i18n("Profile has been reset due to a major update.")) -- v4.0.0 because of major spell restructuring
         return
     end
+
     local defaultProfile = Profile:GetDefaultProfile()
     if profileVersion < 21 then
         ExtendedCharacterStats.general.qualityColorsIntensity = defaultProfile.general.qualityColorsIntensity

--- a/Modules/Migration.lua
+++ b/Modules/Migration.lua
@@ -14,7 +14,6 @@ function Migration:ToLatestProfileVersion(profileVersion)
         ECS:Print(i18n("Profile has been reset due to a major update.")) -- v4.0.0 because of major spell restructuring
         return
     end
-    
     local defaultProfile = Profile:GetDefaultProfile()
     if profileVersion < 21 then
         ExtendedCharacterStats.general.qualityColorsIntensity = defaultProfile.general.qualityColorsIntensity

--- a/Modules/Profile.lua
+++ b/Modules/Profile.lua
@@ -6,7 +6,7 @@ local Utils = ECSLoader:ImportModule("Utils")
 
 ---@return number
 function Profile.GetProfileVersion()
-    return 20
+    return 21
 end
 
 ---@return ECSProfile

--- a/Modules/Profile.lua
+++ b/Modules/Profile.lua
@@ -678,6 +678,7 @@ local function GetDefaultGeneralSettings()
         addColorsToStatTexts = true,
         statColorSelection = "full",
         showQualityColors = true,
+        qualityColorsIntensity = 0.75,
         headerFontSize = 11,
         statFontSize = 10,
         profileVersion = 0,

--- a/Modules/i18n/translations/ConfigTranslations/ConfigTranslations.lua
+++ b/Modules/i18n/translations/ConfigTranslations/ConfigTranslations.lua
@@ -142,6 +142,26 @@ local configTranslations = {
         ["esMX"] = "Muestra/oculta los marcos coloreados alrededor de los objetos equipados",
         ["ptBR"] = "Mostra/oculta os quadros coloridos ao redor dos itens equipados"
     },
+    ["Quality Colors' Intensity"] = {
+        ["enUS"] = true,
+        ["deDE"] = "Intensität der Qualitätsfarben",
+        ["frFR"] = "Intensité des couleurs de qualité",
+        ["zhCN"] = "優質顏色的強度",
+        ["ruRU"] = "Интенсивность качественных цветов",
+        ["esES"] = "Intensidad de los colores de calidad",
+        ["esMX"] = "Intensidad de los colores de calidad",
+        ["ptBR"] = "Intensidade das cores de qualidade"
+    },
+    ["Changes the intensity of the colored frames' glow."] = {
+        ["enUS"] = true,
+        ["deDE"] = "Ändert die Intensität des Leuchtens der farbigen Rahmen.",
+        ["frFR"] = "Modifie l'intensité de l'éclat des cadres colorés.",
+        ["zhCN"] = "改变彩色边框的发光强度。",
+        ["ruRU"] = "Изменяет интенсивность свечения цветных рамок.",
+        ["esES"] = "Cambia la intensidad del brillo de los marcos coloreados.",
+        ["esMX"] = "Cambia la intensidad del brillo de los marcos coloreados.",
+        ["ptBR"] = "Altera a intensidade do brilho dos quadros coloridos."
+    },
     ["Header Font Size"] = {
         ["enUS"] = true,
         ["deDE"] = "Überschriften Schriftgröße",


### PR DESCRIPTION
Adds a slider in the Settings menu that controls the intensity of the glow around equipped items (when "Show Item Quality Colors" is enabled).

![Screenshot_20250220_221744](https://github.com/user-attachments/assets/bffea6dd-d198-4dc4-ac19-aa1977f0e39d)
