### PR TITLE
[feat] Skin main window via ElvUI when loaded

### DIFF
--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -129,8 +129,8 @@ function Stats.CreateWindow()
         end
     end)
 
-    if ElvUI then
-        local E = ElvUI[1]
+    if _G.ElvUI then
+        local E = _G.ElvUI[1]
         local S = E:GetModule("Skins")
         if S then
             S:HandleFrame(mainFrame)

--- a/Modules/Stats.lua
+++ b/Modules/Stats.lua
@@ -129,6 +129,33 @@ function Stats.CreateWindow()
         end
     end)
 
+    if ElvUI then
+        local E = ElvUI[1]
+        local S = E:GetModule("Skins")
+        if S then
+            S:HandleFrame(mainFrame)
+            if mainFrame.CloseButton then
+                mainFrame.CloseButton:SetPoint("TOPRIGHT", 2, 2)
+            end
+            mainFrame.title:ClearAllPoints()
+            mainFrame.title:SetPoint("TOP", mainFrame, "TOP", 0, -8)
+            mainFrame.title:SetFont(E.media.normFont, 13)
+
+            S:HandleButton(mainFrame.configButton)
+            mainFrame.configButton:SetPoint("CENTER", mainFrame, "TOP", -1, -32)
+
+            S:HandleButton(toggleButton)
+
+            local scrollBar = mainFrame.ScrollFrame.ScrollBar
+            if scrollBar then
+                S:HandleScrollBar(scrollBar)
+            end
+
+            mainFrame.ScrollFrame:SetPoint("TOPLEFT", mainFrame, "TOPLEFT", -28, -50)
+            mainFrame.ScrollFrame:SetPoint("BOTTOMRIGHT", mainFrame, "BOTTOMRIGHT", -28, 10)
+        end
+    end
+
     _CreateStatInfos()
     Config.CreateWindow()
 end


### PR DESCRIPTION
## Summary

Adds opt-in ElvUI skinning to the ECS main window. When ElvUI is loaded, the block calls into `E:GetModule(\"Skins\")` to restyle the frame; when ElvUI is absent, the block is a no-op and ECS looks exactly as it does today.

Specifically, in `Modules/Stats.lua` after the main frame is built:

- `S:HandleFrame(mainFrame)` — applies ElvUI's frame template
- Repositions `CloseButton`, `title` (with `E.media.normFont`), and `configButton` so they sit correctly inside the skinned frame
- `S:HandleButton` on `configButton` and `toggleButton`
- `S:HandleScrollBar` on `mainFrame.ScrollFrame.ScrollBar`
- Adjusts `ScrollFrame` anchors so the content area lines up with the skinned border

The whole block is guarded by `if ElvUI then ... if S then ... end end`, so users without ElvUI (or with the Skins module disabled) are unaffected.

## Testing

- Tested on **TBC Classic Anniversary** with ElvUI loaded — main window, config button, toggle button, and scrollbar all render with the ElvUI theme; layout matches the unskinned version.
- Tested without ElvUI on the same client — no regressions, the guard short-circuits cleanly.

I have not personally tested on Classic Era, Wrath Classic, or Retail, but the APIs used (`HandleFrame`, `HandleButton`, `HandleScrollBar`) are present in all ElvUI variants and the code is not gated on `WOW_PROJECT_ID`, so it should behave the same anywhere ECS loads.

## Test plan

- [x] Load ECS + ElvUI on TBC Anniversary, open the ECS window, confirm skinned appearance
- [x] Load ECS without ElvUI, confirm unchanged appearance
- [ ] (Optional) Smoke test on Classic Era / Wrath / Retail with ElvUI