### PR TITLE
fix Boss avoidance value (#452)

### DIFF
--- a/Modules/Data/Data.lua
+++ b/Modules/Data/Data.lua
@@ -62,9 +62,9 @@ dataFunctionRefs = {
     ["AvoidanceBoss"] = function() return Data:GetAvoidance(enemyLevel) end,
     ["DefenseRating"] = function() return ECS.IsClassic and 0 or Data:GetDefenseRating() end,
     ["DefenseValue"] = function() return Data:GetDefenseValue() end,
-    ["DodgeChance"] = function() return Data:GetDodgeChance() end,
-    ["ParryChance"] = function() return Data:GetParryChance() end,
-    ["BlockChance"] = function() return Data:GetBlockChance() end,
+    ["DodgeChance"] = function() return Data:GetDodgeChance(playerLevel) end,
+    ["ParryChance"] = function() return Data:GetParryChance(playerLevel) end,
+    ["BlockChance"] = function() return Data:GetBlockChance(playerLevel) end,
     ["BlockValue"] = function() return Data:GetBlockValue() end,
     ["ResilienceValue"] = function() return ECS.IsClassic and 0 or Data:GetResilienceRating() end,
     -- Spell

--- a/Modules/Data/Defense.lua
+++ b/Modules/Data/Defense.lua
@@ -143,29 +143,37 @@ function _Defense:GetEnemyMissChance(enemyLevel)
     return miss
 end
 
+---@param enemyLevel number
 ---@return number
-function _Defense:GetBlockChance()
+function _Defense:GetBlockChance(enemyLevel)
     local block = 0
     if C_SpellBook.IsSpellKnown(107) and C_PaperDollInfo.OffhandHasShield() then
-       block = GetBlockChance()
+        block = GetBlockChance() + ((UnitLevel("player") - enemyLevel) * .20)
     end
     return block
 end
 
+---@param enemyLevel number
 ---@return number
-function _Defense:GetParryChance()
+function _Defense:GetParryChance(enemyLevel)
     local parry = 0
     if C_SpellBook.IsSpellKnown(3127) or C_SpellBook.IsSpellKnown(18848) or C_SpellBook.IsSpellKnown(3124) then
-        parry = GetParryChance()
+        -- In theory we should compare the player's base defense skill with
+        -- the attacker's weapon skill. Unfortunately there's no API function
+        -- to retrieve the former. The following formula leads to the same
+        -- results except when the player just gained a level and his/her
+        -- defense skill did not catch up yet.
+        parry = GetParryChance() + ((UnitLevel("player") - enemyLevel) * .20)
     end
     return parry
 end
 
+---@param enemyLevel number
 ---@return number
-function _Defense:GetDodgeChance()
+function _Defense:GetDodgeChance(enemyLevel)
     local dodge = 0
     if C_SpellBook.IsSpellKnown(81) then
-        dodge = GetDodgeChance()
+        dodge = GetDodgeChance() + ((UnitLevel("player") - enemyLevel) * .20)
     end
     return dodge
 end
@@ -173,7 +181,7 @@ end
 ---@param enemyLevel number
 ---@return number
 function _Defense:GetAvoidance(enemyLevel)
-    return _Defense:GetEnemyMissChance(enemyLevel) + _Defense:GetBlockChance() + _Defense:GetParryChance() + _Defense:GetDodgeChance()
+    return _Defense:GetEnemyMissChance(enemyLevel) + _Defense:GetBlockChance(enemyLevel) + _Defense:GetParryChance(enemyLevel) + _Defense:GetDodgeChance(enemyLevel)
 end
 
 ---@return number
@@ -191,19 +199,22 @@ function Data:GetDefenseValue()
     return skillRank + skillModifier
 end
 
+---@param enemyLevel number
 ---@return string
-function Data:GetDodgeChance()
-    return DataUtils:Round(_Defense:GetDodgeChance(), 2) .. "%"
+function Data:GetDodgeChance(enemyLevel)
+    return DataUtils:Round(_Defense:GetDodgeChance(enemyLevel), 2) .. "%"
 end
 
+---@param enemyLevel number
 ---@return string
-function Data:GetParryChance()
-    return DataUtils:Round(_Defense:GetParryChance(), 2) .. "%"
+function Data:GetParryChance(enemyLevel)
+    return DataUtils:Round(_Defense:GetParryChance(enemyLevel), 2) .. "%"
 end
 
+---@param enemyLevel number
 ---@return string
-function Data:GetBlockChance()
-    return DataUtils:Round(_Defense:GetBlockChance(), 2) .. "%"
+function Data:GetBlockChance(enemyLevel)
+    return DataUtils:Round(_Defense:GetBlockChance(enemyLevel), 2) .. "%"
 end
 
 ---@param enemyLevel number

--- a/Modules/Data/Defense.lua
+++ b/Modules/Data/Defense.lua
@@ -148,7 +148,7 @@ end
 function _Defense:GetBlockChance(enemyLevel)
     local block = 0
     if C_SpellBook.IsSpellKnown(107) and C_PaperDollInfo.OffhandHasShield() then
-        block = GetBlockChance() + ((UnitLevel("player") - enemyLevel) * .20)
+       block = GetBlockChance() + ((UnitLevel("player") - enemyLevel) * .20)
     end
     return block
 end


### PR DESCRIPTION
The avoidance is the sum of the chances to be missed by, to block, to parry or to dodge an attack from the enemy. Each of these possibilities receives a -0.2 % penalty for every level of the attacker above the player's level.

The code currently takes the level difference in consideration only for the misses. This results in the "Avoidance (Lvl +3)" displayed value to be incorrect, being shown at -0.6 % compared to same-level avoidance, while the difference should be -2.4 %.

Fix this by adding an enemyLevel parameter to the GetDodgeChance, GetParryChance and GetBlockChance methods and using it to properly take the level difference into account in the returned values.