### PR TITLE
Remove Elemental Devastation from spellcrit

### DIFF
--- a/Modules/Data/Constants.lua
+++ b/Modules/Data/Constants.lua
@@ -286,9 +286,6 @@ Data.Aura = {
     },
     SpellCrit = {
         [24907] = ((not ECS.IsClassic) and 5 or nil), -- Moonkin Aura
-        [29177] = 6, -- Elemental Devastation Rank 2
-        [29178] = 9, -- Elemental Devastation Rank 3
-        [30165] = 3, -- Elemental Devastation Rank 1
         [51466] = 3, -- Elemental Oath Rank 1
         [51470] = 5, -- Elemental Oath Rank 2
     },

--- a/Modules/Data/Constants.lua
+++ b/Modules/Data/Constants.lua
@@ -284,11 +284,6 @@ Data.Aura = {
         [25894] = (ECS.IsClassic and 1 or nil), -- Greater Blessing of Wisdom rank 1
         [25918] = (ECS.IsClassic and 1 or nil), -- Greater Blessing of Wisdom rank 2
     },
-    SpellCrit = {
-        [24907] = ((not ECS.IsClassic) and 5 or nil), -- Moonkin Aura
-        [51466] = 3, -- Elemental Oath Rank 1
-        [51470] = 5, -- Elemental Oath Rank 2
-    },
     SpellHaste = {
         [1714] = -50, -- Curse of Tongues Rank 1
         [3603] = -35, -- Distracting Pain

--- a/Modules/Data/SpellCrit.lua
+++ b/Modules/Data/SpellCrit.lua
@@ -34,7 +34,6 @@ function _SpellCrit:GetSpellCritFromBuffs(school)
         local aura = C_UnitAuras.GetBuffDataByIndex("player", i)
         i = i + 1
         if aura and aura.spellId then
-            mod = mod + (Data.Aura.SpellCrit[aura.spellId] or 0)
             if school == Data.FIRE_SCHOOL then
                 if aura.spellId == 28682 then
                     mod = mod + (aura.applications * 10) -- 10% for each stack from Combustion


### PR DESCRIPTION
Elemental Devastation gives melee+ranged crit